### PR TITLE
fix(bot): pass nil params to DeleteWebhook

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -84,7 +84,7 @@ func NewBot(cfg *Config, auth *Auth, logger *slog.Logger) (*Bot, error) {
 
 // Start deletes any stale webhook, starts the send queue goroutine, and begins long-polling.
 func (b *Bot) Start(ctx context.Context) error {
-	if _, err := b.api.DeleteWebhook(ctx, &bot.DeleteWebhookParams{}); err != nil {
+	if _, err := b.api.DeleteWebhook(ctx, nil); err != nil {
 		return fmt.Errorf("bot: deleting webhook: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Fixes bot startup crash: `unexpected end of JSON input` when calling `deleteWebhook`
- Root cause: `go-telegram/bot` v1.20.0 sends an empty multipart form (just boundary markers, no fields) when `DeleteWebhookParams{}` has all zero-value fields with `omitempty`. Telegram rejects this with HTTP 400 and an empty response body, which the library can't JSON-decode.
- Fix: pass `nil` instead of `&bot.DeleteWebhookParams{}` — the library skips form construction entirely and Telegram responds normally.

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [x] Manual verification: bot starts and reaches long polling successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)