### PR TITLE
fix(claude): accept Vertex and Bedrock auth

### DIFF
--- a/internal/claude/manager.go
+++ b/internal/claude/manager.go
@@ -84,8 +84,8 @@ func (m *Manager) Start(ctx context.Context, workDir string) error {
 		return fmt.Errorf("manager: validating work directory: %w", err)
 	}
 
-	if _, ok := os.LookupEnv("ANTHROPIC_API_KEY"); !ok {
-		return fmt.Errorf("manager: ANTHROPIC_API_KEY environment variable is not set")
+	if err := checkClaudeAuth(); err != nil {
+		return err
 	}
 
 	args := []string{
@@ -600,8 +600,8 @@ func (m *Manager) Resume(ctx context.Context, sessionID string) error {
 		return fmt.Errorf("manager: validating work directory: %w", err)
 	}
 
-	if _, ok := os.LookupEnv("ANTHROPIC_API_KEY"); !ok {
-		return fmt.Errorf("manager: ANTHROPIC_API_KEY environment variable is not set")
+	if err := checkClaudeAuth(); err != nil {
+		return err
 	}
 
 	args := []string{
@@ -670,6 +670,21 @@ func (m *Manager) Resume(ctx context.Context, sessionID string) error {
 }
 
 // slogWriter is an io.Writer that writes to slog.Error.
+var claudeAuthEnvVars = []string{
+	"ANTHROPIC_API_KEY",
+	"CLAUDE_CODE_USE_VERTEX",
+	"CLAUDE_CODE_USE_BEDROCK",
+}
+
+func checkClaudeAuth() error {
+	for _, v := range claudeAuthEnvVars {
+		if _, ok := os.LookupEnv(v); ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("manager: no Claude auth configured — set one of: %v", claudeAuthEnvVars)
+}
+
 type slogWriter struct {
 	logger *slog.Logger
 }

--- a/internal/claude/manager_test.go
+++ b/internal/claude/manager_test.go
@@ -130,8 +130,6 @@ func TestStart_Success(t *testing.T) {
 }
 
 func TestStart_MissingAPIKey(t *testing.T) {
-	t.Parallel()
-
 	tmpDir := t.TempDir()
 	mockBin := filepath.Join(tmpDir, "mock_claude.sh")
 	copyFile(t, "mock_claude.sh", mockBin)
@@ -149,13 +147,10 @@ func TestStart_MissingAPIKey(t *testing.T) {
 
 	m := NewManager(cfg, sm, queue, r, slog.Default())
 
-	origKey := os.Getenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	defer func() {
-		if origKey != "" {
-			os.Setenv("ANTHROPIC_API_KEY", origKey)
-		}
-	}()
+	for _, v := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_BEDROCK"} {
+		t.Setenv(v, "")
+		os.Unsetenv(v)
+	}
 
 	ctx := context.Background()
 	if err := sm.Transition(types.StatusStarting); err != nil {
@@ -165,10 +160,10 @@ func TestStart_MissingAPIKey(t *testing.T) {
 	if err == nil {
 		_ = sm.Transition(types.StatusCrashed)
 		_ = sm.Transition(types.StatusIdle)
-		t.Fatal("Start() expected error for missing API key, got nil")
+		t.Fatal("Start() expected error for missing auth, got nil")
 	}
-	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
-		t.Errorf("error = %q, want to contain ANTHROPIC_API_KEY", err)
+	if !strings.Contains(err.Error(), "no Claude auth configured") {
+		t.Errorf("error = %q, want to contain 'no Claude auth configured'", err)
 	}
 	_ = sm.Transition(types.StatusCrashed)
 	_ = sm.Transition(types.StatusIdle)


### PR DESCRIPTION
## Summary
- The startup auth check now accepts `CLAUDE_CODE_USE_VERTEX` and `CLAUDE_CODE_USE_BEDROCK` in addition to `ANTHROPIC_API_KEY`
- Previously the hardcoded `ANTHROPIC_API_KEY` check blocked users authenticating through Google Vertex AI or AWS Bedrock
- Extracts auth validation into a shared `checkClaudeAuth()` function used by both `Start()` and `Resume()`

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [x] `TestStart_MissingAPIKey` updated to verify all three env vars are checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)