### PR TITLE
fix(bot): transition to running on init event

### DIFF
--- a/internal/bot/eventloop.go
+++ b/internal/bot/eventloop.go
@@ -217,9 +217,12 @@ func (el *EventLoop) handleResult(event router.ClassifiedEvent) {
 func (el *EventLoop) handleSystem(event router.ClassifiedEvent) {
 	el.logger.Info("eventloop: system event", "subtype", event.Event.Subtype, "session_id", event.Event.SessionID)
 
-	// Handle init event - set session ID
+	// Handle init event — set session ID and transition starting → running
 	if event.Event.Subtype == "init" && event.Event.SessionID != "" {
 		el.state.SetSessionID(event.Event.SessionID)
+		if el.state.TransitionStatus(types.StatusStarting, types.StatusRunning) {
+			el.logger.Info("eventloop: session ready", "session_id", event.Event.SessionID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Bot was stuck in "starting" state after subprocess launched successfully
- The `handleSystem` method set the session ID on the init event but never transitioned the state machine from `starting` → `running`
- Users saw: `Cannot send prompt: command prompt not allowed in state starting`
- Per spec: `idle → starting → (init event) → running`

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [ ] Manual: start bot, `/begin`, verify `/status` shows "running" and prompts are accepted