### PR TITLE
fix(bot): detect session start from system events

### DIFF
--- a/internal/bot/eventloop.go
+++ b/internal/bot/eventloop.go
@@ -217,12 +217,14 @@ func (el *EventLoop) handleResult(event router.ClassifiedEvent) {
 func (el *EventLoop) handleSystem(event router.ClassifiedEvent) {
 	el.logger.Info("eventloop: system event", "subtype", event.Event.Subtype, "session_id", event.Event.SessionID)
 
-	// Handle init event — set session ID and transition starting → running
-	if event.Event.Subtype == "init" && event.Event.SessionID != "" {
+	// Set session ID and transition starting → running on the first system
+	// event that carries a session_id. Claude Code emits hook_started (not
+	// "init") as its first system event, so we match on any subtype.
+	if event.Event.SessionID != "" && el.state.SessionID() == "" {
 		el.state.SetSessionID(event.Event.SessionID)
-		if el.state.TransitionStatus(types.StatusStarting, types.StatusRunning) {
-			el.logger.Info("eventloop: session ready", "session_id", event.Event.SessionID)
-		}
+	}
+	if el.state.TransitionStatus(types.StatusStarting, types.StatusRunning) {
+		el.logger.Info("eventloop: session ready", "session_id", el.state.SessionID())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Bot was stuck in "starting" because it expected a `subtype: "init"` system event that Claude Code never sends
- Claude Code emits `hook_started`/`hook_response` as its first system events, not `"init"`
- Now transitions `starting → running` on the first system event carrying a `session_id`, regardless of subtype

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [ ] Manual: `/begin`, verify `/status` shows "running" and prompts are accepted