### PR TITLE
fix(claude): append newline before feeding to router

### DIFF
--- a/internal/claude/manager.go
+++ b/internal/claude/manager.go
@@ -440,7 +440,7 @@ func (m *Manager) startStdoutReader(ctx context.Context) {
 				continue
 			}
 
-			if err := m.router.Feed(line); err != nil {
+			if err := m.router.Feed(append(line, '\n')); err != nil {
 				m.logger.Error("manager: feeding line to router", "error", err)
 			}
 		}


### PR DESCRIPTION
## Summary
- **This was the real reason no events reached the EventLoop** — not the init subtype issue
- `bufio.Scanner` strips trailing newlines, but `router.Feed` uses `ReadBytes('\n')` to delimit lines
- Without the newline, data accumulated in the router's buffer indefinitely and was never processed
- All events (system, text, tool_use, result) were silently dropped, keeping the bot stuck in "starting"

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [ ] Manual: `/begin`, verify `/status` shows "running" and events flow through