### PR TITLE
feat(mcp): add stdio MCP shim for tool approval

### DIFF
--- a/cmd/craudinei/main.go
+++ b/cmd/craudinei/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/decko/craudinei/internal/bot"
 	"github.com/decko/craudinei/internal/claude"
 	"github.com/decko/craudinei/internal/config"
+	"github.com/decko/craudinei/internal/mcp"
 	"github.com/decko/craudinei/internal/router"
 	"github.com/decko/craudinei/internal/types"
 
@@ -26,10 +27,30 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "mcp-shim" {
+		if err := runMCPShim(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func runMCPShim() error {
+	fs := flag.NewFlagSet("mcp-shim", flag.ExitOnError)
+	port := fs.Int("port", 0, "approval server port")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		return err
+	}
+	if *port == 0 {
+		return fmt.Errorf("mcp-shim: --port is required")
+	}
+	return mcp.Run(*port)
 }
 
 // run wires all components together, starts the bot and approval server,

--- a/internal/approval/approval_adversary_test.go
+++ b/internal/approval/approval_adversary_test.go
@@ -243,42 +243,46 @@ func TestGenerateMCPConfigValidJSON(t *testing.T) {
 		t.Fatal("mcpServers key missing or not a map")
 	}
 
-	// Must have "approval" server
-	approval, ok := mcpServers["approval"].(map[string]any)
+	// Must have "craudinei" server
+	craudinei, ok := mcpServers["craudinei"].(map[string]any)
 	if !ok {
-		t.Fatal("mcpServers.approval missing or not a map")
+		t.Fatal("mcpServers.craudinei missing or not a map")
 	}
 
-	// Must have "command" set to "curl"
-	cmd, ok := approval["command"].(string)
+	// Must have "command" set to the test binary
+	cmd, ok := craudinei["command"].(string)
 	if !ok {
-		t.Fatal("approval.command missing or not a string")
+		t.Fatal("craudinei.command missing or not a string")
 	}
-	if cmd != "curl" {
-		t.Errorf("command = %q, want %q", cmd, "curl")
+	if cmd == "" {
+		t.Error("craudinei.command is empty")
 	}
 
-	// Must have "args" array
-	args, ok := approval["args"].([]any)
+	// Must have "args" containing mcp-shim and port
+	args, ok := craudinei["args"].([]any)
 	if !ok {
-		t.Fatal("approval.args missing or not an array")
-	}
-	if len(args) == 0 {
-		t.Error("approval.args is empty")
+		t.Fatal("craudinei.args missing or not an array")
 	}
 
-	// Must contain the server URL with 127.0.0.1
 	port := srv.Port()
-	expectedHost := fmt.Sprintf("127.0.0.1:%d", port)
-	found := false
+	expectedPort := fmt.Sprintf("%d", port)
+	foundShim := false
+	foundPort := false
 	for _, a := range args {
-		if s, ok := a.(string); ok && strings.Contains(s, expectedHost) {
-			found = true
-			break
+		if s, ok := a.(string); ok {
+			if s == "mcp-shim" {
+				foundShim = true
+			}
+			if s == expectedPort {
+				foundPort = true
+			}
 		}
 	}
-	if !found {
-		t.Errorf("MCP config args = %v, want one to contain %q", args, expectedHost)
+	if !foundShim {
+		t.Errorf("MCP config args = %v, want to contain mcp-shim", args)
+	}
+	if !foundPort {
+		t.Errorf("MCP config args = %v, want to contain port %s", args, expectedPort)
 	}
 }
 

--- a/internal/approval/server.go
+++ b/internal/approval/server.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -111,10 +112,15 @@ func (s *Server) Stop() {
 }
 
 // GenerateMCPConfig produces the MCP server configuration JSON that tells
-// Claude Code how to connect to this approval server.
+// Claude Code how to connect to the approval MCP shim.
 func (s *Server) GenerateMCPConfig() (string, error) {
 	if s.listener == nil {
 		return "", fmt.Errorf("approval: server not started")
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("approval: resolving executable path: %w", err)
 	}
 
 	port := s.Port()
@@ -128,13 +134,11 @@ func (s *Server) GenerateMCPConfig() (string, error) {
 			Command string   `json:"command"`
 			Args    []string `json:"args"`
 		}{
-			"approval": {
-				Command: "curl",
+			"craudinei": {
+				Command: exe,
 				Args: []string{
-					"-X", "POST",
-					"-H", "Content-Type: application/json",
-					"-d", "@-",
-					fmt.Sprintf("http://127.0.0.1:%d/approval", port),
+					"mcp-shim",
+					"--port", fmt.Sprintf("%d", port),
 				},
 			},
 		},

--- a/internal/approval/server_test.go
+++ b/internal/approval/server_test.go
@@ -152,10 +152,15 @@ func TestMCPConfigGeneration(t *testing.T) {
 		t.Error("Port() = 0 before GenerateMCPConfig, want non-zero")
 	}
 
-	// Should contain the port in the URL
-	expectedPort := fmt.Sprintf("127.0.0.1:%d", port)
+	// Should contain the port in the args
+	expectedPort := fmt.Sprintf("%d", port)
 	if !strings.Contains(cfgOut, expectedPort) {
-		t.Errorf("GenerateMCPConfig() = %s, want to contain %s", cfgOut, expectedPort)
+		t.Errorf("GenerateMCPConfig() = %s, want to contain port %s", cfgOut, expectedPort)
+	}
+
+	// Should use craudinei server name
+	if !strings.Contains(cfgOut, `"craudinei"`) {
+		t.Errorf("GenerateMCPConfig() = %s, want to contain craudinei server", cfgOut)
 	}
 }
 

--- a/internal/claude/manager.go
+++ b/internal/claude/manager.go
@@ -99,7 +99,7 @@ func (m *Manager) Start(ctx context.Context, workDir string) error {
 		args = append(args, "--allowedTools", tool)
 	}
 	args = append(args,
-		"--permission-prompt-tool", "craudinei_approval",
+		"--permission-prompt-tool", "mcp__craudinei__approval",
 		"--mcp-config", "/tmp/craudinei-mcp.json",
 		"--max-turns", fmt.Sprintf("%d", m.cfg.Claude.MaxTurns),
 		"--max-budget-usd", fmt.Sprintf("%f", m.cfg.Claude.MaxBudgetUSD),
@@ -616,7 +616,7 @@ func (m *Manager) Resume(ctx context.Context, sessionID string) error {
 		args = append(args, "--allowedTools", tool)
 	}
 	args = append(args,
-		"--permission-prompt-tool", "craudinei_approval",
+		"--permission-prompt-tool", "mcp__craudinei__approval",
 		"--mcp-config", "/tmp/craudinei-mcp.json",
 		"--max-turns", fmt.Sprintf("%d", m.cfg.Claude.MaxTurns),
 		"--max-budget-usd", fmt.Sprintf("%f", m.cfg.Claude.MaxBudgetUSD),

--- a/internal/mcp/shim.go
+++ b/internal/mcp/shim.go
@@ -1,0 +1,232 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const toolName = "approval"
+
+var toolInputSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"tool_name": {
+			"type": "string",
+			"description": "The name of the tool requesting permission"
+		},
+		"input": {
+			"type": "object",
+			"description": "The input for the tool",
+			"additionalProperties": true
+		},
+		"tool_use_id": {
+			"type": "string",
+			"description": "The unique tool use request ID"
+		}
+	},
+	"required": ["tool_name", "input"]
+}`)
+
+type jsonrpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type jsonrpcResponse struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id"`
+	Result  any    `json:"result,omitempty"`
+	Error   any    `json:"error,omitempty"`
+}
+
+type mcpTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+type toolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type permissionInput struct {
+	ToolName  string         `json:"tool_name"`
+	Input     map[string]any `json:"input"`
+	ToolUseID string         `json:"tool_use_id,omitempty"`
+}
+
+type approvalHTTPRequest struct {
+	ToolName  string         `json:"tool_name"`
+	ToolInput map[string]any `json:"tool_input"`
+}
+
+type approvalHTTPResponse struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason"`
+}
+
+type allowResponse struct {
+	Behavior     string         `json:"behavior"`
+	UpdatedInput map[string]any `json:"updatedInput"`
+}
+
+type denyResponse struct {
+	Behavior string `json:"behavior"`
+	Message  string `json:"message"`
+}
+
+type textContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// Run starts the MCP stdio server. It reads JSON-RPC requests from stdin
+// and writes responses to stdout, proxying tool calls to the approval
+// HTTP server at the given port.
+func Run(port int) error {
+	approvalURL := fmt.Sprintf("http://127.0.0.1:%d/approval", port)
+	client := &http.Client{Timeout: 10 * time.Minute}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		var req jsonrpcRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			writeError(os.Stdout, nil, -32700, "parse error")
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			writeResult(os.Stdout, req.ID, map[string]any{
+				"protocolVersion": "2024-11-05",
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "craudinei", "version": "1.0.0"},
+			})
+
+		case "notifications/initialized":
+			// No response needed for notifications
+
+		case "tools/list":
+			writeResult(os.Stdout, req.ID, map[string]any{
+				"tools": []mcpTool{{
+					Name:        toolName,
+					Description: "Request user approval for a tool call via Telegram",
+					InputSchema: toolInputSchema,
+				}},
+			})
+
+		case "tools/call":
+			resp, err := handleToolCall(req.Params, approvalURL, client)
+			if err != nil {
+				writeResult(os.Stdout, req.ID, map[string]any{
+					"content": []textContent{{Type: "text", Text: err.Error()}},
+					"isError": true,
+				})
+			} else {
+				writeResult(os.Stdout, req.ID, map[string]any{
+					"content": []textContent{{Type: "text", Text: resp}},
+				})
+			}
+
+		default:
+			writeError(os.Stdout, req.ID, -32601, "method not found: "+req.Method)
+		}
+	}
+
+	return scanner.Err()
+}
+
+func handleToolCall(params json.RawMessage, approvalURL string, client *http.Client) (string, error) {
+	var call toolCallParams
+	if err := json.Unmarshal(params, &call); err != nil {
+		return "", fmt.Errorf("invalid tool call params: %w", err)
+	}
+
+	if call.Name != toolName {
+		return "", fmt.Errorf("unknown tool: %s", call.Name)
+	}
+
+	var input permissionInput
+	if err := json.Unmarshal(call.Arguments, &input); err != nil {
+		return "", fmt.Errorf("invalid tool input: %w", err)
+	}
+
+	// Forward to HTTP approval server
+	httpReq := approvalHTTPRequest{
+		ToolName:  input.ToolName,
+		ToolInput: input.Input,
+	}
+	body, err := json.Marshal(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("marshalling request: %w", err)
+	}
+
+	resp, err := client.Post(approvalURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("calling approval server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+
+	var httpResp approvalHTTPResponse
+	if err := json.Unmarshal(respBody, &httpResp); err != nil {
+		return "", fmt.Errorf("decoding response: %w", err)
+	}
+
+	// Translate approval server response to Claude Code's expected format
+	var result []byte
+	switch httpResp.Decision {
+	case "approve":
+		result, _ = json.Marshal(allowResponse{
+			Behavior:     "allow",
+			UpdatedInput: input.Input,
+		})
+	default:
+		msg := httpResp.Reason
+		if msg == "" {
+			msg = "User denied this action"
+		}
+		result, _ = json.Marshal(denyResponse{
+			Behavior: "deny",
+			Message:  msg,
+		})
+	}
+
+	return string(result), nil
+}
+
+func writeResult(w io.Writer, id any, result any) {
+	resp := jsonrpcResponse{JSONRPC: "2.0", ID: id, Result: result}
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(w, "%s\n", data)
+}
+
+func writeError(w io.Writer, id any, code int, message string) {
+	resp := jsonrpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   map[string]any{"code": code, "message": message},
+	}
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(w, "%s\n", data)
+}


### PR DESCRIPTION
## Summary
- Replaces the non-functional curl-based MCP config with a proper MCP stdio server
- Adds `internal/mcp/shim.go`: JSON-RPC 2.0 server implementing `initialize`, `tools/list`, `tools/call`
- Adds `mcp-shim` subcommand to craudinei binary — Claude Code spawns it as `craudinei mcp-shim --port <port>`
- `GenerateMCPConfig` now uses `os.Executable()` for reliable path resolution
- `--permission-prompt-tool` updated to `mcp__craudinei__approval`
- Translates HTTP approval responses (`decision`/`reason`) to Claude Code's expected format (`behavior: allow/deny`)

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [x] MCP shim smoke test: `initialize` and `tools/list` return correct JSON-RPC responses
- [ ] Manual: `/begin`, trigger a tool that needs approval, verify approval card appears with tool name/input