### PR TITLE
fix(bot): auto-reset crashed state on /begin

### DIFF
--- a/internal/bot/handlers.go
+++ b/internal/bot/handlers.go
@@ -146,6 +146,14 @@ func (h *Handlers) HandleBegin(ctx context.Context, api interface{}, update *Upd
 		h.auditLogger.Command(userID, "begin", workDir, "started", "")
 	}
 
+	// Auto-reset from crashed to idle before starting
+	if sm.Status() == types.StatusCrashed {
+		if err := sm.Transition(types.StatusIdle); err != nil {
+			h.sendReplyf(ctx, chatID, "Failed to reset session: %v", err)
+			return
+		}
+	}
+
 	// Transition to starting
 	if err := sm.Transition(types.StatusStarting); err != nil {
 		h.sendReplyf(ctx, chatID, "Failed to start session: %v", err)


### PR DESCRIPTION
## Summary
- `/begin` failed with "cannot transition from crashed to starting" after a previous session crash
- State machine requires `crashed → idle → starting`, but `/begin` only attempted the direct `crashed → starting` transition
- Now auto-resets to idle when the current state is crashed before transitioning to starting

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [ ] Manual: crash a session, then `/begin` again — should work without restart