### PR TITLE
fix(claude): drop -p flag for interactive sessions

### DIFF
--- a/internal/claude/manager.go
+++ b/internal/claude/manager.go
@@ -89,7 +89,6 @@ func (m *Manager) Start(ctx context.Context, workDir string) error {
 	}
 
 	args := []string{
-		"-p",
 		"--input-format", "stream-json",
 		"--output-format", "stream-json",
 		"--verbose",
@@ -605,7 +604,6 @@ func (m *Manager) Resume(ctx context.Context, sessionID string) error {
 	}
 
 	args := []string{
-		"-p",
 		"--input-format", "stream-json",
 		"--output-format", "stream-json",
 		"--verbose",


### PR DESCRIPTION
## Summary
- The `-p` (print) flag caused Claude Code to exit after a single response, dropping the session to idle
- Removing it while keeping `--input-format stream-json` + `--output-format stream-json` gives multi-turn interactive sessions
- The process stays alive and accepts multiple prompts via stdin

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [x] Verified: Claude Code without `-p` stays alive and waits for input via stream-json
- [ ] Manual: `/begin`, send multiple prompts, verify session stays in "running" state