### PR TITLE
fix(router): silently ignore unknown event subtypes

### DIFF
--- a/internal/router/events.go
+++ b/internal/router/events.go
@@ -16,6 +16,7 @@ const (
 	ActionRateLimit Action = "rate_limit" // rate limit hit
 	ActionAPIRetry  Action = "api_retry"  // API retry with countdown
 	ActionError     Action = "error"      // error event
+	ActionIgnore    Action = "ignore"     // unrecognized event, silently skip
 )
 
 // ClassifiedEvent represents an event that has been classified for handling.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -99,8 +99,7 @@ func ClassifyEvent(event types.Event) ClassifiedEvent {
 		case "api_retry":
 			action = ActionAPIRetry
 		default:
-			action = ActionError
-			text = "unknown assistant subtype"
+			action = ActionIgnore
 		}
 
 	case types.EventResult:
@@ -111,8 +110,7 @@ func ClassifyEvent(event types.Event) ClassifiedEvent {
 		action = ActionRateLimit
 
 	default:
-		action = ActionError
-		text = "unknown event type"
+		action = ActionIgnore
 	}
 
 	return ClassifiedEvent{

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -92,11 +92,8 @@ func TestClassifyEvent_UnknownType(t *testing.T) {
 	event := types.Event{Type: types.EventUser}
 	got := ClassifyEvent(event)
 
-	if got.Action != ActionError {
-		t.Errorf("Action = %v, want %v", got.Action, ActionError)
-	}
-	if got.Text != "unknown event type" {
-		t.Errorf("Text = %v, want %v", got.Text, "unknown event type")
+	if got.Action != ActionIgnore {
+		t.Errorf("Action = %v, want %v", got.Action, ActionIgnore)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Unknown assistant subtypes and event types were classified as `ActionError`, sending red error messages to Telegram
- These are normal Claude Code events (e.g. `server_tool_use`, `tool_result`) that the router doesn't need to handle yet
- Added `ActionIgnore` — unknown types/subtypes are now silently skipped instead of surfaced as errors

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green with `-race`)
- [ ] Manual: interact with bot, verify no more red error messages for unrecognized events